### PR TITLE
B submit evidence with correct param nesting as specified in the contract

### DIFF
--- a/lib/payment/organization_connector.rb
+++ b/lib/payment/organization_connector.rb
@@ -139,16 +139,17 @@ module ShorePayment
       handle_response(:get, response, path, 'dispute')
     end
 
-    # Update +Dispute+
+    # Update +Dispute+ (i.e. add new evidence).
     #
+    # @param dispute_id [String] +Dispute+ ID.
     # @param evidence [Hash<String,Object>] Dispute evidence.
     #
     # @return [Hash<String,Object>] JSON respresentation of the +Dispute+.
     # @raise [RuntimeError] Request failed.
-    def update_dispute(dispute_id:, evidence:)
+    def update_dispute(dispute_id, payload = {})
       base_path = '/v1'
       path = "#{base_path}/disputes/#{dispute_id}"
-      response = HttpRetriever.authenticated_put(path, query: evidence)
+      response = HttpRetriever.authenticated_put(path, query: payload)
       handle_response(:put, response, path)
     end
 

--- a/lib/payment/response_classes/dispute.rb
+++ b/lib/payment/response_classes/dispute.rb
@@ -21,10 +21,7 @@ module ShorePayment
 
     def update(new_evidence)
       OrganizationConnector.new(organization_id)
-                           .update_dispute(
-                             dispute_id: id,
-                             evidence: new_evidence
-                           )
+                           .update_dispute(id, evidence: new_evidence)
     end
 
     def self.collection_from_payment_service(params = {})

--- a/spec/payment/organization_connector_spec.rb
+++ b/spec/payment/organization_connector_spec.rb
@@ -299,7 +299,7 @@ describe ShorePayment::OrganizationConnector do
         .and_return(mock_created('{}'))
 
       expect(
-        subject.update_dispute(dispute_id: fake_id, evidence: {})
+        subject.update_dispute(fake_id, evidence: {})
       ).to eq({})
     end
 


### PR DESCRIPTION
The payment connector used to submit params like `customer_name` at the
"top-level". However, according to the payment service contract these params
should be submitted as `params[evidence][customer_name].

ping @sadtuna