### PR TITLE
B [#PS-64] catch date parsing errors

### DIFF
--- a/lib/payment/response_classes/merchant_stripe.rb
+++ b/lib/payment/response_classes/merchant_stripe.rb
@@ -14,6 +14,8 @@ module ShorePayment
         month: date.month,
         day: date.day
       ) if date
+    rescue
+      nil
     end
 
     private

--- a/spec/payment/merchant_stripe_spec.rb
+++ b/spec/payment/merchant_stripe_spec.rb
@@ -150,17 +150,23 @@ describe ShorePayment::MerchantStripe do
         legal_entity.dob.year = nil
         legal_entity.dob.month = nil
         legal_entity.dob.day = nil
-        expect(legal_entity.dob_date).to eq(nil)
+        expect(legal_entity.dob_date).to be_nil
 
         legal_entity.dob.year = ''
         legal_entity.dob.month = ''
         legal_entity.dob.day = ''
-        expect(legal_entity.dob_date).to eq(nil)
+        expect(legal_entity.dob_date).to be_nil
 
         legal_entity.dob.year = 2015
         legal_entity.dob.month = nil
         legal_entity.dob.day = nil
-        expect(legal_entity.dob_date).to eq(nil)
+        expect(legal_entity.dob_date).to be_nil
+      end
+
+      it 'returns nil if the dob_date is invalid' do
+        expect do
+          legal_entity.dob_date = 'invalid'
+        end.not_to change(legal_entity, :dob)
       end
     end
 


### PR DESCRIPTION
don't raise an error, if the given date is invalid.