### PR TITLE
F [#PS-122] remove nil values when converting legal_entity to hash

### DIFF
--- a/lib/payment/response_classes/merchant_stripe.rb
+++ b/lib/payment/response_classes/merchant_stripe.rb
@@ -110,8 +110,23 @@ module ShorePayment
       (additional_owners || []).length + 1
     end
 
-    def as_hash
-      JSON.parse(to_json)
+    def as_hash(with_nil = false)
+      r = JSON.parse(to_json)
+      deep_reject_nil!(r) unless with_nil
+      r
+    end
+
+    private
+
+    def deep_reject_nil!(h)
+      h.each_key do |k|
+        deep_reject_nil!(h[k]) if h[k].is_a?(Hash)
+        next unless h[k].is_a?(Array)
+        h[k].each do |a|
+          deep_reject_nil!(a)
+        end
+      end
+      h.reject! { |_k, v| v.nil? || v == {} }
     end
   end
 


### PR DESCRIPTION
An attempt to fix bug: https://shore.myjetbrains.com/youtrack/issue/PS-122 (every environment).

The reason for this bug: in core BO when we get a merchant's legal_entity object from payment-service, we get the object with all attributes, even with ones without value (nil) (This is could be an unexpected change on stripe side, I couldn't find out yet). After updating some attributes, we send back this whole object to the payment-service (and stripe), where this empty, nil (and untouched) fields are interpreted as 'attribute deleting request'.

In an attempt to fix this unexpected behaviour, I remove all nil and empty hash values before I send back the legal_entity object. If we'd like to delete an attribute we would set it to empty string anyway (and not nil).