### PR TITLE
Allow activesupport to upgrade

### DIFF
--- a/payment-connector.gemspec
+++ b/payment-connector.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'httparty', '~> 0.10.2'
-  spec.add_dependency 'activesupport', '~> 3.2'
+  spec.add_dependency 'activesupport', '>= 3.2'
   spec.add_dependency 'tzinfo', '~> 0.3'
 
   spec.add_development_dependency 'bundler', '~> 1.10'


### PR DESCRIPTION
I would like to be able to upgrade activesupport to version 4 in projects where I use payment-connector. @ceigel @sadtuna 